### PR TITLE
Handle getter/setter object

### DIFF
--- a/vue-computed-promise.js
+++ b/vue-computed-promise.js
@@ -30,7 +30,13 @@ var VueComputedPromise = {
 					let promiseInitiated = false;
 					this.$options.computed[key] = function() {
 						let data = this.$data;
-						let result = oldComputed[key].call(this);
+						let result;
+						// Computed property can be either object or function
+						if (typeof oldComputed[key] === "object") {
+							result = oldComputed[key];
+						} else {
+							result = oldComputed[key].call(this);
+						}
 
             if(result && typeof result === "function") {
 							if(!promiseInitiated) {


### PR DESCRIPTION
This change makes vue-computed-promise work with getter/setter objects. It's probably not ideal, since we don't make any effort to support promise in such object's `get()` method, but it's better than current state where code will just error out on encountering anything that's not callable.